### PR TITLE
Added a .gitignore, require JDK >= 11 for compilation (due to a bug in older JDK versions), fix a crash that would occur upon respawn, properly handle a `ArrayIndexOutOfBoundsException` that can sometimes occur

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,101 @@
+# Maven
+# https://github.com/github/gitignore/blob/master/Maven.gitignore
+# --------
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+# https://github.com/takari/maven-wrapper#usage-without-binary-jar
+.mvn/wrapper/maven-wrapper.jar
+
+# Eclipse m2e generated files
+# Eclipse Core
+.project
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
+
+# IntelliJ IDEA
+# https://github.com/github/gitignore/blob/master/Global/JetBrains.gitignore
+# --------
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,8 @@
     <version>1.0-SNAPSHOT</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
     <repositories>
         <repository>
@@ -39,6 +41,27 @@
             </resource>
         </resources>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>enforce-java</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                    <version>11</version>
+                                    <message>A JDK version of 11 or higher is required to build DirtMultiVersion due to a bug that exists in earlier versions of the JDK. For more information, please see this JDK issue report (JDK-8144832): https://bugs.openjdk.java.net/browse/JDK-8144832</message>
+                                </requireJavaVersion>
+                            </rules>    
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>

--- a/src/main/java/com/github/dirtpowered/dirtmv/data/protocol/PacketData.java
+++ b/src/main/java/com/github/dirtpowered/dirtmv/data/protocol/PacketData.java
@@ -71,7 +71,11 @@ public class PacketData {
     }
 
     public <T> T read(TypeObject<T> type, int index) {
-        return type.getType().cast(objects[index].getObject());
+        try {
+            return type.getType().cast(objects[index].getObject());
+        } catch (ArrayIndexOutOfBoundsException e) {
+            return null;
+        }
     }
 
     public PacketOutput toMessage() throws IOException {

--- a/src/main/java/com/github/dirtpowered/dirtmv/network/versions/Release28To23/ProtocolRelease28To23.java
+++ b/src/main/java/com/github/dirtpowered/dirtmv/network/versions/Release28To23/ProtocolRelease28To23.java
@@ -248,7 +248,7 @@ public class ProtocolRelease28To23 extends ServerProtocol {
             public PacketData translate(ServerSession session, PacketData data) {
 
                 return PacketUtil.createPacket(0x09, new TypeHolder[]{
-                        set(Type.BYTE, (byte) data.read(0).getObject()),
+                        set(Type.INT, (int) data.read(0).getObject()),
                         data.read(1),
                         data.read(2),
                         data.read(3),


### PR DESCRIPTION
This PR enforces a requirement of JDK version >= 11 for compilation (while still targeting Java 8 for runtime compatibility purposes).

Without that requirement, older JDK versions (such as JDK 8) will completely fail to compile DirtMultiVersion due to changes made in commit fe7f2c97cfe04b847ba07336486820f619d46907.

This is the result of a JDK bug that was only fixed in JDK 11. For more information, please see this JDK issue report (JDK-8144832): https://bugs.openjdk.java.net/browse/JDK-8144832

Proper handling was also added for an `ArrayIndexOutOfBoundsException` that can occur when encountering a zero-length array while connecting to certain Minecraft server versions.

I also fixed a crash that would occur upon respawn due to the incorrect type being used (another bug that also originates from commit fe7f2c97cfe04b847ba07336486820f619d46907).

There's also a `.gitignore` file now that handles both the Maven build system and the IntelliJ IDEA IDE.